### PR TITLE
update calculation of outErr

### DIFF
--- a/mkFit/GenMPlexOps.pl
+++ b/mkFit/GenMPlexOps.pl
@@ -129,3 +129,18 @@ $temp_propErrT_x_simil_propErr = new GenMul::MatrixSym('name'=>'c', 'M'=>$propEr
 $m->dump_multiply_std_and_intrinsic("upParam_propErrT_x_simil_propErr.ah",
 									$propErrT, $temp_simil_x_propErr, $temp_propErrT_x_simil_propErr);
 									
+
+$kalmanGain66 = new GenMul::Matrix('name'=>'a', 'M'=>$propErr_M, 'N'=>$propErr_M);
+$kalmanGain66->set_pattern(<<"FNORD");
+x x x 0 0 0
+x x x 0 0 0
+x x x 0 0 0
+x x x 0 0 0
+x x x 0 0 0
+x x x 0 0 0
+FNORD
+
+$temp_kalmanGain_x_propErr = new GenMul::MatrixSym('name'=>'c', 'M'=>$propErrT_M);
+
+$m->dump_multiply_std_and_intrinsic("upParam_kalmanGain_x_propErr.ah",
+									$kalmanGain66, $propErr, $temp_kalmanGain_x_propErr);


### PR DESCRIPTION
Ok. I think I have the hang of this pull request thing.
I have 2 compile errors, as you'll see.
1) The compiler claims that there isn't a version of InvertCramer for a MPlexHS
2) The compiler says that "-" is not overloaded for MPlexLS - MPlexLS, so either you have some other way you want to do it (which would probably be good because it would get rid of a temporary), or that operator needs to be overloaded.
